### PR TITLE
Set 'Name' in the desktop file to something reasonable.

### DIFF
--- a/acoustid-fingerprinter.desktop
+++ b/acoustid-fingerprinter.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=acoustid-fingerprinter
+Name=Acoustid Fingerprinter
 Exec=acoustid-fingerprinter
 Icon=acoustid-fingerprinter
-GenericName=AcoustID Music fingerprinting tool
+GenericName=Acoustid Music fingerprinting tool
 
 Terminal=false
 Type=Application


### PR DESCRIPTION
This is the field that's used for display in Gnome 3, so make it
short(ish) and sweet.
Also use consistent capitalization on the GenericName.
