### PR TITLE
Compatibility with FFmpeg 0.11 API changes

### DIFF
--- a/decoder.h
+++ b/decoder.h
@@ -121,7 +121,11 @@ inline Decoder::~Decoder()
 		avcodec_close(m_codec_ctx);
 	}
 	if (m_format_ctx) {
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(53, 2, 0)
 		av_close_input_file(m_format_ctx);
+#else
+		avformat_close_input(&m_format_ctx);
+#endif
 	}
 #ifdef HAVE_AV_AUDIO_CONVERT
 	if (m_convert_ctx) {
@@ -136,7 +140,11 @@ inline bool Decoder::Open()
 {
     QMutexLocker locker(&m_mutex); 
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(53, 2, 0)
 	if (av_open_input_file(&m_format_ctx, m_file_name.c_str(), NULL, 0, NULL) != 0) {
+#else
+	if (avformat_open_input(&m_format_ctx, m_file_name.c_str(), NULL, NULL) != 0) {
+#endif
 		m_error = "Couldn't open the file." + m_file_name;
 		return false;
 	}
@@ -177,7 +185,11 @@ inline bool Decoder::Open()
     }
 	m_codec_open = true;
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(52, 94, 1)
 	if (m_codec_ctx->sample_fmt != SAMPLE_FMT_S16) {
+#else
+	if (m_codec_ctx->sample_fmt != AV_SAMPLE_FMT_S16) {
+#endif
 #ifdef HAVE_AV_AUDIO_CONVERT
 		m_convert_ctx = av_audio_convert_alloc(AV_SAMPLE_FMT_S16, m_codec_ctx->channels,
 		                                       (AVSampleFormat)m_codec_ctx->sample_fmt, m_codec_ctx->channels, NULL, 0);
@@ -251,7 +263,11 @@ inline void Decoder::Decode(FingerprintCalculator *consumer, int max_length)
 			if (m_convert_ctx) {
 				const void *ibuf[6] = { m_buffer1 };
 				void *obuf[6] = { m_buffer2 };
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51, 8, 0)
 				int istride[6] = { av_get_bits_per_sample_format(m_codec_ctx->sample_fmt) / 8 };
+#else
+				int istride[6] = { av_get_bytes_per_sample(m_codec_ctx->sample_fmt) };
+#endif
 				int ostride[6] = { 2 };
 				int len = buffer_size / istride[0];
 				if (av_audio_convert(m_convert_ctx, obuf, ostride, ibuf, istride, len) < 0) {


### PR DESCRIPTION
Patch based on chromaprint commit 1402a244da, uses preprocessor macros
to detect ffmpeg API versions.
